### PR TITLE
.crab extension

### DIFF
--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -183,12 +183,12 @@ fn check_name(
                 "\n\
                 If you need a binary with the name \"{name}\", use a valid package \
                 name, and set the binary name to be different from the package. \
-                This can be done by setting the binary filename to `src/bin/{name}.rs` \
+                This can be done by setting the binary filename to `src/bin/{name}.crab` \
                 or change the name in Cargo.toml with:\n\
                 \n    \
                 [[bin]]\n    \
                 name = \"{name}\"\n    \
-                path = \"src/main.rs\"\n\
+                path = \"src/main.crab\"\n\
             ",
                 name = name
             ));
@@ -296,27 +296,27 @@ fn detect_source_paths_and_types(
 
     let tests = vec![
         Test {
-            proposed_path: "src/main.rs".to_string(),
+            proposed_path: "src/main.crab".to_string(),
             handling: H::Bin,
         },
         Test {
-            proposed_path: "main.rs".to_string(),
+            proposed_path: "main.crab".to_string(),
             handling: H::Bin,
         },
         Test {
-            proposed_path: format!("src/{}.rs", name),
+            proposed_path: format!("src/{}.crab", name),
             handling: H::Detect,
         },
         Test {
-            proposed_path: format!("{}.rs", name),
+            proposed_path: format!("{}.crab", name),
             handling: H::Detect,
         },
         Test {
-            proposed_path: "src/lib.rs".to_string(),
+            proposed_path: "src/lib.crab".to_string(),
             handling: H::Lib,
         },
         Test {
-            proposed_path: "lib.rs".to_string(),
+            proposed_path: "lib.crab".to_string(),
             handling: H::Lib,
         },
     ];
@@ -392,13 +392,13 @@ cannot automatically generate Cargo.toml as the main target would be ambiguous",
 fn plan_new_source_file(bin: bool, package_name: String) -> SourceFileInformation {
     if bin {
         SourceFileInformation {
-            relative_path: "src/main.rs".to_string(),
+            relative_path: "src/main.crab".to_string(),
             target_name: package_name,
             bin: true,
         }
     } else {
         SourceFileInformation {
-            relative_path: "src/lib.rs".to_string(),
+            relative_path: "src/lib.crab".to_string(),
             target_name: package_name,
             bin: false,
         }
@@ -782,7 +782,7 @@ fn mk(config: &Config, opts: &MkOptions<'_>) -> CargoResult<()> {
     // Calculate what `[lib]` and `[[bin]]`s we need to append to `Cargo.toml`.
     for i in &opts.source_files {
         if i.bin {
-            if i.relative_path != "src/main.rs" {
+            if i.relative_path != "src/main.crab" {
                 let mut bin = toml_edit::Table::new();
                 bin["name"] = toml_edit::value(i.target_name.clone());
                 bin["path"] = toml_edit::value(i.relative_path.clone());
@@ -794,7 +794,7 @@ fn mk(config: &Config, opts: &MkOptions<'_>) -> CargoResult<()> {
                     .expect("bin is an array of tables")
                     .push(bin);
             }
-        } else if i.relative_path != "src/lib.rs" {
+        } else if i.relative_path != "src/lib.crab" {
             let mut lib = toml_edit::Table::new();
             lib["name"] = toml_edit::value(i.target_name.clone());
             lib["path"] = toml_edit::value(i.relative_path.clone());

--- a/src/cargo/util/toml/targets.rs
+++ b/src/cargo/util/toml/targets.rs
@@ -184,11 +184,11 @@ fn clean_lib(
         (Some(path), _) => package_root.join(&path.0),
         (None, Some(path)) => path,
         (None, None) => {
-            let legacy_path = package_root.join("src").join(format!("{}.rs", lib.name()));
+            let legacy_path = package_root.join("src").join(format!("{}.crab", lib.name()));
             if edition == Edition::Edition2015 && legacy_path.exists() {
                 warnings.push(format!(
                     "path `{}` was erroneously implicitly accepted for library `{}`,\n\
-                     please rename the file to `src/lib.rs` or set lib.path in Cargo.toml",
+                     please rename the file to `src/lib.crab` or set lib.path in Cargo.toml",
                     legacy_path.display(),
                     lib.name()
                 ));
@@ -196,7 +196,7 @@ fn clean_lib(
             } else {
                 anyhow::bail!(
                     "can't find library `{}`, \
-                     rename file to `src/lib.rs` or specify lib.path",
+                     rename file to `src/lib.crab` or specify lib.path",
                     lib.name()
                 )
             }
@@ -355,12 +355,12 @@ fn clean_bins(
 
     fn legacy_bin_path(package_root: &Path, name: &str, has_lib: bool) -> Option<PathBuf> {
         if !has_lib {
-            let path = package_root.join("src").join(format!("{}.rs", name));
+            let path = package_root.join("src").join(format!("{}.crab", name));
             if path.exists() {
                 return Some(path);
             }
         }
-        let path = package_root.join("src").join("main.rs");
+        let path = package_root.join("src").join("main.crab");
         if path.exists() {
             return Some(path);
         }
@@ -368,7 +368,7 @@ fn clean_bins(
         let path = package_root
             .join("src")
             .join(DEFAULT_BIN_DIR_NAME)
-            .join("main.rs");
+            .join("main.crab");
         if path.exists() {
             return Some(path);
         }
@@ -466,7 +466,7 @@ fn clean_benches(
 
     let targets = {
         let mut legacy_bench_path = |bench: &TomlTarget| {
-            let legacy_path = package_root.join("src").join("bench.rs");
+            let legacy_path = package_root.join("src").join("bench.crab");
             if !(bench.name() == "bench" && legacy_path.exists()) {
                 return None;
             }
@@ -589,7 +589,7 @@ fn clean_targets_with_legacy_path(
 }
 
 fn inferred_lib(package_root: &Path) -> Option<PathBuf> {
-    let lib = package_root.join("src").join("lib.rs");
+    let lib = package_root.join("src").join("lib.crab");
     if lib.exists() {
         Some(lib)
     } else {
@@ -598,7 +598,7 @@ fn inferred_lib(package_root: &Path) -> Option<PathBuf> {
 }
 
 fn inferred_bins(package_root: &Path, package_name: &str) -> Vec<(String, PathBuf)> {
-    let main = package_root.join("src").join("main.rs");
+    let main = package_root.join("src").join("main.crab");
     let mut result = Vec::new();
     if main.exists() {
         result.push((package_name.to_string(), main));
@@ -626,7 +626,7 @@ fn infer_from_directory(directory: &Path) -> Vec<(String, PathBuf)> {
 fn infer_any(entry: &DirEntry) -> Option<(String, PathBuf)> {
     if entry.file_type().map_or(false, |t| t.is_dir()) {
         infer_subdirectory(entry)
-    } else if entry.path().extension().and_then(|p| p.to_str()) == Some("rs") {
+    } else if entry.path().extension().and_then(|p| p.to_str()) == Some("crab") {
         infer_file(entry)
     } else {
         None
@@ -642,7 +642,7 @@ fn infer_file(entry: &DirEntry) -> Option<(String, PathBuf)> {
 
 fn infer_subdirectory(entry: &DirEntry) -> Option<(String, PathBuf)> {
     let path = entry.path();
-    let main = path.join("main.rs");
+    let main = path.join("main.crab");
     let name = path.file_name().and_then(|n| n.to_str());
     match (name, main.exists()) {
         (Some(name), true) => Some((name.to_owned(), main)),
@@ -868,11 +868,11 @@ fn target_path_not_found_error_message(
 
         let target_path_file = {
             let mut path = target_path.clone();
-            path.set_extension("rs");
+            path.set_extension("crab");
             path
         };
         let target_path_subdir = {
-            target_path.push("main.rs");
+            target_path.push("main.crab");
             target_path
         };
         return [target_path_file, target_path_subdir];


### PR DESCRIPTION
this changes the file extension that `cargo` looks for (and uses in `cargo new`) from `.rs` to `.crab`. used with the renamed toolchain this can also be used with `crabgo`.

it currently needs to be built using the existing upstream `cargo` command. this isn't ideal, but to fix would probably require adding the ability to use both `.rs` and `.crab`, which would a more intense task.

to test:
```bash
/path/to/cargo build --release
/path/to/target/release/cargo new hello
```

for whatever reason, building cargo directly allows it to be renamed, where the normal install script does not. so doing this:

```bash
cp /path/to/target/release/cargo /path/to/.cargo/bin/crabgo
```

works fine and allows `crabgo` to live alongside `cargo`.


this resolves https://github.com/crablang/crab/issues/20